### PR TITLE
Fixed naming of list test-case inside `TestSmartLambdaParseParameter`

### DIFF
--- a/tests/test_smart_lambda_parse_parameter.py
+++ b/tests/test_smart_lambda_parse_parameter.py
@@ -40,7 +40,7 @@ class TestSmartLambdaParseParameter(unittest.TestCase):
         self.assertEqual(expected, parameter, f"Smart-Lambda parameter not matching: {expected} != {parameter}")
 
     @test("SMART-LAMBDA PARSE-PARAMETER UNUSED-PARAMETER")
-    def testParseTwoParameter(self):
+    def testParseUnusedParameter(self):
         # Unused parameter aren't loaded
         expected = [Parameter('x')]
 


### PR DESCRIPTION
Fixed naming of last test-case inside `TestSmartLambdaParseParameter`,
this will ensure the second-last test-case will be executed.

Resolves #19