### PR TITLE
Fixed link to badge for unit-tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Licence: MIT](https://img.shields.io/github/license/Linner-Thomas/smart-lambda)](https://github.com/Linner-Thomas/smart-lambda/blob/main/LICENSE)
-[![Unit Tests](https://github.com/Linner-Thomas/smart-lambda/actions/workflows/python-unit-test.yml/badge.svg)](https://github.com/Linner-Thomas/smart-lambda/actions/workflows/python-unit-test.yml)
+[![Unit Tests](https://github.com/Linner-Thomas/smart-lambda/actions/workflows/python-build.yml/badge.svg)](https://github.com/Linner-Thomas/smart-lambda/actions/workflows/python-build.yml)
 [![codecov](https://codecov.io/gh/Linner-Thomas/smart-lambda/branch/develop/graph/badge.svg)](https://codecov.io/gh/Linner-Thomas/smart-lambda)
 
 # smart-lambda


### PR DESCRIPTION
Fixed link to badge for unit-tests inside readme.

Resolves #24