### PR TITLE
20 refactor and split parser

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,11 +12,13 @@ setup(
     packages=
     [
         'smart_lambda',
+        'smart_lambda.parser',
     ],
 
     package_dir=
     {
         'smart_lambda': 'smart_lambda',
+        'smart_lambda.parser': 'smart_lambda/parser',
     },
 
     author="Thomas Linner",

--- a/smart_lambda/core.py
+++ b/smart_lambda/core.py
@@ -32,7 +32,6 @@ class SmartLambda:
 
         self.__parse()
 
-        self.__parse_parameter()
         self.__parse_constants()
         self.__parse_binary_operations()
 
@@ -40,19 +39,13 @@ class SmartLambda:
         """
         TODO
         """
+        # Parse lambda-function and return lexemes
         self.lexemes = self.parser.parse()
 
-    def __parse_parameter(self) -> None:
-        """
-        Parse all parameter from underlying lambda-function and store internally.
-        """
-        # Iterate over all instructions in lambda-function
-        for instruction in dis.get_instructions(self.function):
-            # Local variable
-            # In case of lambda-functions, there shouldn't be any local variables
-            # These only contain the function-parameter
-            if instruction.opname == 'LOAD_FAST':
-                self.parameter.append(Parameter(instruction.argval))
+        # Split lexemes into "type" for better accessibility
+        for lexeme in self.lexemes:
+            if isinstance(lexeme, Parameter):
+                self.parameter.append(lexeme)
 
     def __parse_constants(self) -> None:
         """

--- a/smart_lambda/core.py
+++ b/smart_lambda/core.py
@@ -1,9 +1,7 @@
 from typing import Callable, TypeVar
 
-import dis
-
 from smart_lambda.parser.parser_lambda import ParserLambda
-from smart_lambda.lexeme import BinaryOperation, BinaryOperations, Constant, Parameter
+from smart_lambda.lexeme import Parameter, Constant, BinaryOperation
 
 # Define type-variable for lambda return-type
 T = TypeVar('T')
@@ -32,8 +30,6 @@ class SmartLambda:
 
         self.__parse()
 
-        self.__parse_binary_operations()
-
     def __parse(self) -> None:
         """
         TODO
@@ -49,46 +45,8 @@ class SmartLambda:
             if isinstance(lexeme, Constant):
                 self.constants.append(lexeme)
 
-    def __parse_binary_operations(self) -> None:
-        """
-        Parse all binary-operations from underlying lambda-function and store internally.
-        """
-        [print(instruction) for instruction in dis.get_instructions(self.function)]
-        # TODO: Currently only works for parameter!
-        # This will probably require a rework of the whole parser system, because we need the last two operands,
-        # which can be a mixture of constants and parameter ...
-
-        # Iterate over all instructions in lambda-function
-        for instruction in dis.get_instructions(self.function):
-            # Addition
-            if instruction.opname == 'BINARY_ADD':
-                operands = self.parameter[-2:]
-                self.binary_operations.append(BinaryOperation(BinaryOperations.ADD, operands))
-
-            # Subtraction
-            if instruction.opname == 'BINARY_SUBTRACT':
-                operands = self.parameter[-2:]
-                self.binary_operations.append(BinaryOperation(BinaryOperations.SUB, operands))
-
-            # Multiplication
-            if instruction.opname == 'BINARY_MULTIPLY':
-                operands = self.parameter[-2:]
-                self.binary_operations.append(BinaryOperation(BinaryOperations.MUL, operands))
-
-            # True-Division
-            if instruction.opname == 'BINARY_TRUE_DIVIDE':
-                operands = self.parameter[-2:]
-                self.binary_operations.append(BinaryOperation(BinaryOperations.DIV_TRUE, operands))
-
-            # Floor-Division
-            if instruction.opname == 'BINARY_FLOOR_DIVIDE':
-                operands = self.parameter[-2:]
-                self.binary_operations.append(BinaryOperation(BinaryOperations.DIV_FLOOR, operands))
-
-            # Modulo
-            if instruction.opname == 'BINARY_MODULO':
-                operands = self.parameter[-2:]
-                self.binary_operations.append(BinaryOperation(BinaryOperations.MOD, operands))
+            if isinstance(lexeme, BinaryOperation):
+                self.binary_operations.append(lexeme)
 
     def __call__(self, *args, **kwargs) -> T:
         """

--- a/smart_lambda/core.py
+++ b/smart_lambda/core.py
@@ -2,6 +2,7 @@ from typing import Callable, TypeVar
 
 import dis
 
+from smart_lambda.parser.parser_lambda import ParserLambda
 from smart_lambda.lexeme import BinaryOperation, BinaryOperations, Constant, Parameter
 
 # Define type-variable for lambda return-type
@@ -22,13 +23,24 @@ class SmartLambda:
         :param function: Lambda-Function
         """
         self.function = function
+        self.parser = ParserLambda(function)
+
+        self.lexemes = []
         self.parameter = []
         self.constants = []
         self.binary_operations = []
 
+        self.__parse()
+
         self.__parse_parameter()
         self.__parse_constants()
         self.__parse_binary_operations()
+
+    def __parse(self) -> None:
+        """
+        TODO
+        """
+        self.lexemes = self.parser.parse()
 
     def __parse_parameter(self) -> None:
         """

--- a/smart_lambda/parser/parser_binary_operation.py
+++ b/smart_lambda/parser/parser_binary_operation.py
@@ -1,0 +1,35 @@
+from typing import List, Union
+
+from dis import Instruction
+
+from smart_lambda.lexeme import Lexeme, BinaryOperation, BinaryOperations
+from smart_lambda.parser.parser_lexeme import ParserLexeme
+
+
+class ParserBinaryOperation(ParserLexeme):
+    """
+    TODO
+    """
+    # List of valid instructions for the parameter-parser
+    instructions = \
+        {
+            'BINARY_ADD': BinaryOperations.ADD,
+            'BINARY_SUBTRACT': BinaryOperations.SUB,
+            'BINARY_MULTIPLY': BinaryOperations.MUL,
+            'BINARY_TRUE_DIVIDE': BinaryOperations.DIV_TRUE,
+            'BINARY_FLOOR_DIVIDE': BinaryOperations.DIV_FLOOR,
+            'BINARY_MODULO': BinaryOperations.MOD
+        }
+
+    @classmethod
+    def parse(cls, lexemes: List[Lexeme], instruction: Instruction) -> Union[BinaryOperation, None]:
+        """
+        Parses the given instruction and returns a corresponding binary-operation.
+        Might return None in special cases.
+
+        :param lexemes: List of already parsed lexemes
+        :param instruction: Instruction to parse
+
+        :return: Binary-Operation
+        """
+        return BinaryOperation(cls.instructions[instruction.opname], lexemes[-2:])

--- a/smart_lambda/parser/parser_constant.py
+++ b/smart_lambda/parser/parser_constant.py
@@ -1,0 +1,70 @@
+from typing import List, Union
+
+from dis import Instruction
+
+from smart_lambda.lexeme import Lexeme, Constant
+from smart_lambda.parser.parser_lexeme import ParserLexeme
+
+
+class ParserConstant(ParserLexeme):
+    """
+    TODO
+    """
+    # List of valid instructions for the parameter-parser
+    instructions =\
+        [
+            'LOAD_CONST',
+            'BUILD_LIST',
+            'LIST_EXTEND',
+            'BUILD_SET',
+            'BUILD_CONST_KEY_MAP'
+        ]
+
+    @classmethod
+    def parse(cls, lexemes: List[Lexeme], instruction: Instruction) -> Union[Constant, None]:
+        """
+        Parses the given instruction and returns a corresponding parameter.
+        Might return None in special cases.
+
+        :param lexemes: List of already parsed lexemes
+        :param instruction: Instruction to parse
+
+        :return: Constant
+        """
+        # Primitive-Constant (int, str, ...) and tuple
+        if instruction.opname == 'LOAD_CONST':
+            if isinstance(instruction.argval, frozenset):
+                return Constant(set(instruction.argval))
+
+            return Constant(instruction.argval)
+
+        # List-Constant (`argval` stores entry-count)
+        if instruction.opname == 'BUILD_LIST' and instruction.argval > 0:
+            # Get last `argval` lexemes, these are constants by definition
+            list_constants = [constant.value for constant in lexemes[-instruction.argval:]]
+            del lexemes[-instruction.argval:]
+            return Constant(list_constants)
+
+        # List-Constant (>= 3.9, entries loaded as single tuple for long lists)
+        if instruction.opname == 'LIST_EXTEND':
+            list_constants = lexemes[-1].value
+            del lexemes[-1]
+            return Constant(list(list_constants))
+
+        # Set-Constant (`argval` stores entry-count)
+        if instruction.opname == 'BUILD_SET' and instruction.argval > 0:
+            # Get last `argval` lexemes, these are constants by definition
+            set_constants = [constant.value for constant in lexemes[-instruction.argval:]]
+            del lexemes[-instruction.argval:]
+            return Constant(set(set_constants))
+
+        # Dict-Constant
+        # Values get loaded separate using 'LOAD_CONST'
+        # Keys get loaded as tuple using 'LOAD_CONST'
+        if instruction.opname == 'BUILD_CONST_KEY_MAP':
+            dict_keys = lexemes[-1].value
+            dict_vals = [constant.value for constant in lexemes[-instruction.argval - 1:-1]]
+            del lexemes[-instruction.argval - 1:]
+            return Constant({key: val for key, val in zip(dict_keys, dict_vals)})
+
+        return None

--- a/smart_lambda/parser/parser_lambda.py
+++ b/smart_lambda/parser/parser_lambda.py
@@ -1,6 +1,8 @@
-from typing import Callable, List, TypeVar
+from dis import Instruction, get_instructions
+from typing import Callable, List, TypeVar, Union
 
 from smart_lambda.lexeme import Lexeme
+from smart_lambda.parser.parser_lexeme import ParserLexeme
 
 # Define type-variable for lambda return-type
 T = TypeVar('T')
@@ -24,4 +26,24 @@ class ParserLambda:
 
         :return: List of lexemes
         """
-        return []
+        lexemes = []
+
+        for instruction in get_instructions(self.function):
+            parser = self.get_parser(instruction)
+
+            if parser is not None:
+                lexemes.append(parser.parse(instruction))
+
+        return lexemes
+
+    def get_parser(self, instruction: Instruction) -> Union[ParserLexeme, None]:
+        """
+        Returns the responsible lexeme-parser for a given instruction.
+        Might return None if no parser was found.
+
+        :param instruction: Instruction to get parser for
+
+        :return: Lexeme-Parser for instruction or None
+        """
+        # TODO Get parser for instruction
+        return None

--- a/smart_lambda/parser/parser_lambda.py
+++ b/smart_lambda/parser/parser_lambda.py
@@ -3,6 +3,7 @@ from typing import Callable, List, TypeVar, Union
 
 from smart_lambda.lexeme import Lexeme
 from smart_lambda.parser.parser_lexeme import ParserLexeme
+from smart_lambda.parser.parser_parameter import ParserParameter
 
 # Define type-variable for lambda return-type
 T = TypeVar('T')
@@ -12,6 +13,11 @@ class ParserLambda:
     """
     TODO
     """
+    available_parser: List[ParserLexeme] =\
+        [
+            ParserParameter
+        ]
+
     def __init__(self, function: Callable[..., T]):
         """
         Initialize new lambda-parser based on given lambda-function.
@@ -45,5 +51,8 @@ class ParserLambda:
 
         :return: Lexeme-Parser for instruction or None
         """
-        # TODO Get parser for instruction
+        for parser in self.available_parser:
+            if parser.is_valid_instruction(instruction):
+                return parser
+
         return None

--- a/smart_lambda/parser/parser_lambda.py
+++ b/smart_lambda/parser/parser_lambda.py
@@ -5,6 +5,7 @@ from smart_lambda.lexeme import Lexeme
 from smart_lambda.parser.parser_lexeme import ParserLexeme
 from smart_lambda.parser.parser_parameter import ParserParameter
 from smart_lambda.parser.parser_constant import ParserConstant
+from smart_lambda.parser.parser_binary_operation import ParserBinaryOperation
 
 # Define type-variable for lambda return-type
 T = TypeVar('T')
@@ -17,7 +18,8 @@ class ParserLambda:
     available_parser: List[ParserLexeme] =\
         [
             ParserParameter,
-            ParserConstant
+            ParserConstant,
+            ParserBinaryOperation
         ]
 
     def __init__(self, function: Callable[..., T]):

--- a/smart_lambda/parser/parser_lambda.py
+++ b/smart_lambda/parser/parser_lambda.py
@@ -4,6 +4,7 @@ from typing import Callable, List, TypeVar, Union
 from smart_lambda.lexeme import Lexeme
 from smart_lambda.parser.parser_lexeme import ParserLexeme
 from smart_lambda.parser.parser_parameter import ParserParameter
+from smart_lambda.parser.parser_constant import ParserConstant
 
 # Define type-variable for lambda return-type
 T = TypeVar('T')
@@ -15,7 +16,8 @@ class ParserLambda:
     """
     available_parser: List[ParserLexeme] =\
         [
-            ParserParameter
+            ParserParameter,
+            ParserConstant
         ]
 
     def __init__(self, function: Callable[..., T]):
@@ -38,7 +40,10 @@ class ParserLambda:
             parser = self.get_parser(instruction)
 
             if parser is not None:
-                lexemes.append(parser.parse(instruction))
+                lexeme = parser.parse(lexemes, instruction)
+
+                if lexeme is not None:
+                    lexemes.append(lexeme)
 
         return lexemes
 

--- a/smart_lambda/parser/parser_lambda.py
+++ b/smart_lambda/parser/parser_lambda.py
@@ -1,0 +1,27 @@
+from typing import Callable, List, TypeVar
+
+from smart_lambda.lexeme import Lexeme
+
+# Define type-variable for lambda return-type
+T = TypeVar('T')
+
+
+class ParserLambda:
+    """
+    TODO
+    """
+    def __init__(self, function: Callable[..., T]):
+        """
+        Initialize new lambda-parser based on given lambda-function.
+
+        :param function: Lambda-Function to parse
+        """
+        self.function = function
+
+    def parse(self) -> List[Lexeme]:
+        """
+        Parse the internal lambda-function and return list of lexemes.
+
+        :return: List of lexemes
+        """
+        return []

--- a/smart_lambda/parser/parser_lexeme.py
+++ b/smart_lambda/parser/parser_lexeme.py
@@ -1,0 +1,34 @@
+from dis import Instruction
+
+from smart_lambda.lexeme import Lexeme
+
+
+class ParserLexeme:
+    """
+    TODO
+    """
+    # List of valid instructions for the lexeme-parser
+    instructions = []
+
+    @classmethod
+    def parse(cls, instruction: Instruction) -> Lexeme:
+        """
+        Parses the given instruction and returns a corresponding lexeme.
+        This method has to be overridden by each lexeme-parser.
+
+        :param instruction: Instruction to parse
+
+        :return: Lexeme
+        """
+        pass
+
+    @classmethod
+    def is_valid_instruction(cls, instruction: Instruction) -> bool:
+        """
+        Check whether the given instruction is valid for the lexeme-parser.
+
+        :param instruction: Instruction to check
+
+        :return: True / False
+        """
+        return instruction.opname in cls.instructions

--- a/smart_lambda/parser/parser_lexeme.py
+++ b/smart_lambda/parser/parser_lexeme.py
@@ -1,3 +1,5 @@
+from typing import List, Union
+
 from dis import Instruction
 
 from smart_lambda.lexeme import Lexeme
@@ -11,11 +13,14 @@ class ParserLexeme:
     instructions = []
 
     @classmethod
-    def parse(cls, instruction: Instruction) -> Lexeme:
+    def parse(cls, lexemes: List[Lexeme], instruction: Instruction) -> Union[Lexeme, None]:
         """
         Parses the given instruction and returns a corresponding lexeme.
+        Might return None in special cases.
+
         This method has to be overridden by each lexeme-parser.
 
+        :param lexemes: List of already parsed lexemes
         :param instruction: Instruction to parse
 
         :return: Lexeme

--- a/smart_lambda/parser/parser_parameter.py
+++ b/smart_lambda/parser/parser_parameter.py
@@ -1,6 +1,8 @@
+from typing import List, Union
+
 from dis import Instruction
 
-from smart_lambda.lexeme import Parameter
+from smart_lambda.lexeme import Lexeme, Parameter
 from smart_lambda.parser.parser_lexeme import ParserLexeme
 
 
@@ -15,10 +17,12 @@ class ParserParameter(ParserLexeme):
         ]
 
     @classmethod
-    def parse(cls, instruction: Instruction) -> Parameter:
+    def parse(cls, lexemes: List[Lexeme], instruction: Instruction) -> Union[Parameter, None]:
         """
         Parses the given instruction and returns a corresponding parameter.
+        Might return None in special cases.
 
+        :param lexemes: List of already parsed lexemes
         :param instruction: Instruction to parse
 
         :return: Parameter

--- a/smart_lambda/parser/parser_parameter.py
+++ b/smart_lambda/parser/parser_parameter.py
@@ -1,0 +1,26 @@
+from dis import Instruction
+
+from smart_lambda.lexeme import Parameter
+from smart_lambda.parser.parser_lexeme import ParserLexeme
+
+
+class ParserParameter(ParserLexeme):
+    """
+    TODO
+    """
+    # List of valid instructions for the parameter-parser
+    instructions =\
+        [
+            'LOAD_FAST'
+        ]
+
+    @classmethod
+    def parse(cls, instruction: Instruction) -> Parameter:
+        """
+        Parses the given instruction and returns a corresponding parameter.
+
+        :param instruction: Instruction to parse
+
+        :return: Parameter
+        """
+        return Parameter(instruction.argval)


### PR DESCRIPTION
Split parsing-functionality into separate package: `parser`

Implemented `ParserLexeme` as base-class for all lexeme-parsers.
Added implementations for specific leximes:

- Parameter
- Constant
- Binary-Operation

Additionally the `SmartLambda` now stores a list of all parsed lexemes,
this should be useful for parsing binary-operations with an combination
of parameter and constants.