### PR TITLE
Call `parse`-method of base-class `ParserLexeme` in sub-parser.

### DIFF
--- a/smart_lambda/parser/parser_binary_operation.py
+++ b/smart_lambda/parser/parser_binary_operation.py
@@ -32,4 +32,6 @@ class ParserBinaryOperation(ParserLexeme):
 
         :return: Binary-Operation
         """
+        super().parse(lexemes, instruction)
+
         return BinaryOperation(cls.instructions[instruction.opname], lexemes[-2:])

--- a/smart_lambda/parser/parser_constant.py
+++ b/smart_lambda/parser/parser_constant.py
@@ -31,6 +31,8 @@ class ParserConstant(ParserLexeme):
 
         :return: Constant
         """
+        super().parse(lexemes, instruction)
+
         # Primitive-Constant (int, str, ...) and tuple
         if instruction.opname == 'LOAD_CONST':
             if isinstance(instruction.argval, frozenset):

--- a/smart_lambda/parser/parser_parameter.py
+++ b/smart_lambda/parser/parser_parameter.py
@@ -27,4 +27,6 @@ class ParserParameter(ParserLexeme):
 
         :return: Parameter
         """
+        super().parse(lexemes, instruction)
+
         return Parameter(instruction.argval)


### PR DESCRIPTION
Call `parse`-method of base-class `ParserLexeme` in sub-parser.

Resolves #27