### PR TITLE
29 add test cases for binary operations with mixed parameter and constant operands

### DIFF
--- a/smart_lambda/lexeme.py
+++ b/smart_lambda/lexeme.py
@@ -25,7 +25,7 @@ class Constant(Lexeme):
         self.type: type = type(value)
 
     def __repr__(self) -> str:
-        return str(self.value)
+        return f"Constant({self.value})"
 
     def __eq__(self, other: Constant) -> bool:
         """
@@ -35,6 +35,9 @@ class Constant(Lexeme):
 
         :return: True / False
         """
+        if not isinstance(other, Constant):
+            return False
+
         return self.type == other.type and self.value == other.value
 
 
@@ -51,7 +54,7 @@ class Parameter(Lexeme):
         self.name: str = name
 
     def __repr__(self):
-        return self.name
+        return f"Parameter({self.name})"
 
     def __eq__(self, other: Parameter) -> bool:
         """
@@ -61,6 +64,9 @@ class Parameter(Lexeme):
 
         :return: True / False
         """
+        if not isinstance(other, Parameter):
+            return False
+
         return self.name == other.name
 
 
@@ -103,4 +109,7 @@ class BinaryOperation(Lexeme):
 
         :return: True / False
         """
+        if not isinstance(other, BinaryOperation):
+            return False
+
         return self.operation == other.operation and self.operands == other.operands

--- a/tests/test_lexeme.py
+++ b/tests/test_lexeme.py
@@ -1,0 +1,156 @@
+import unittest
+from util import test
+
+from smart_lambda.lexeme import Constant, Parameter, BinaryOperation, BinaryOperations
+
+
+class TestLexeme(unittest.TestCase):
+    @test("LEXEME CONSTANT REPR-NONE")
+    def testConstantReprNone(self):
+        expected = f"Constant(None)"
+
+        print(f"\t Validate: Constant(None) -> {expected}")
+
+        constant = Constant(None)
+
+        self.assertEqual(expected, constant.__repr__(),
+                         f"Constant-Lexeme representation not matching: {expected} != {constant.__repr__()}")
+
+    @test("LEXEME CONSTANT REPR-INT")
+    def testConstantReprInt(self):
+        expected = f"Constant(1)"
+
+        print(f"\t Validate: Constant(1) -> {expected}")
+
+        constant = Constant(1)
+
+        self.assertEqual(expected, constant.__repr__(),
+                         f"Constant-Lexeme representation not matching: {expected} != {constant.__repr__()}")
+
+    @test("LEXEME CONSTANT REPR-STR")
+    def testConstantReprStr(self):
+        expected = f"Constant(str)"
+
+        print(f"\t Validate: Constant('str') -> {expected}")
+
+        constant = Constant('str')
+
+        self.assertEqual(expected, constant.__repr__(),
+                         f"Constant-Lexeme representation not matching: {expected} != {constant.__repr__()}")
+
+    @test("LEXEME CONSTANT EQ-TRUE")
+    def testConstantEqTrue(self):
+        print(f"\t Validate: Constant(1) == Constant(1) -> {True}")
+
+        result = Constant(1) == Constant(1)
+
+        self.assertEqual(True, result,
+                         f"Constant-Lexeme equality not matching: {True} != {result}")
+
+    @test("LEXEME CONSTANT EQ-FALSE")
+    def testConstantEqFalse(self):
+        print(f"\t Validate: Constant(1) == Constant(2) -> {False}")
+
+        result = Constant(1) == Constant(2)
+
+        self.assertEqual(False, result,
+                         f"Constant-Lexeme equality not matching: {True} != {result}")
+
+    @test("LEXEME CONSTANT EQ-WRONG-TYPE")
+    def testConstantEqFalse(self):
+        print(f"\t Validate: Constant('x') == Parameter('x') -> {False}")
+
+        result = Constant('x') == Parameter('x')
+
+        self.assertEqual(False, result,
+                         f"Constant-Lexeme equality not matching: {True} != {result}")
+
+    @test("LEXEME PARAMETER REPR")
+    def testConstantReprInt(self):
+        expected = f"Parameter(x)"
+
+        print(f"\t Validate: Parameter('x') -> {expected}")
+
+        parameter = Parameter('x')
+
+        self.assertEqual(expected, parameter.__repr__(),
+                         f"Parameter-Lexeme representation not matching: {expected} != {parameter.__repr__()}")
+
+    @test("LEXEME PARAMETER EQ-TRUE")
+    def testParameterEqTrue(self):
+        print(f"\t Validate: Parameter('x') == Parameter('x') -> {True}")
+
+        result = Parameter('x') == Parameter('x')
+
+        self.assertEqual(True, result,
+                         f"Parameter-Lexeme equality not matching: {True} != {result}")
+
+    @test("LEXEME PARAMETER EQ-FALSE")
+    def testParameterEqFalse(self):
+        print(f"\t Validate: Parameter('x') == Parameter('y') -> {False}")
+
+        result = Parameter('x') == Parameter('y')
+
+        self.assertEqual(False, result,
+                         f"Parameter-Lexeme equality not matching: {True} != {result}")
+
+    @test("LEXEME PARAMETER EQ-WRONG-TYPE")
+    def testParameterEqFalse(self):
+        print(f"\t Validate: Parameter('x') == Constant('x') -> {False}")
+
+        result = Parameter('x') == Constant('x')
+
+        self.assertEqual(False, result,
+                         f"Parameter-Lexeme equality not matching: {True} != {result}")
+
+    @test("LEXEME BINARY-OPERATION REPR-CONST-PARAM")
+    def testBinaryOperationReprConstParam(self):
+        expected = f"Constant(1) + Parameter(x)"
+
+        print(f"\t Validate: BinaryOperation(BinaryOperations.ADD, [Constant(1), Parameter('x')]) -> {expected}")
+
+        operation = BinaryOperation(BinaryOperations.ADD, [Constant(1), Parameter('x')])
+
+        self.assertEqual(expected, operation.__repr__(),
+                         f"Binary-Operation-Lexeme representation not matching: {expected} != {operation.__repr__()}")
+
+    @test("LEXEME BINARY-OPERATION REPR-PARAM-CONST")
+    def testBinaryOperationReprParamConst(self):
+        expected = f"Parameter(x) + Constant(1)"
+
+        print(f"\t Validate: BinaryOperation(BinaryOperations.ADD, [Parameter('x'), Constant(1)]) -> {expected}")
+
+        operation = BinaryOperation(BinaryOperations.ADD, [Parameter('x'), Constant(1)])
+
+        self.assertEqual(expected, operation.__repr__(),
+                         f"Binary-Operation-Lexeme representation not matching: {expected} != {operation.__repr__()}")
+
+    @test("LEXEME BINARY-OPERATION EQ-TRUE")
+    def testBinaryOperationEqTrue(self):
+        print(f"\t Validate: Constant(1) + Constant(2) == Constant(1) + Constant(2) -> {True}")
+
+        result = BinaryOperation(BinaryOperations.ADD, [Constant(1), Constant(2)]) == \
+                 BinaryOperation(BinaryOperations.ADD, [Constant(1), Constant(2)])
+
+        self.assertEqual(True, result,
+                         f"Binary-Operation-Lexeme equality not matching: {True} != {result}")
+
+    @test("LEXEME BINARY-OPERATION EQ-FALSE-OPERATION")
+    def testBinaryOperationEqFalseOperation(self):
+        print(f"\t Validate: Constant(1) + Constant(2) == Constant(1) - Constant(2) -> {False}")
+
+        result = BinaryOperation(BinaryOperations.ADD, [Constant(1), Constant(2)]) == \
+                 BinaryOperation(BinaryOperations.SUB, [Constant(1), Constant(2)])
+
+        self.assertEqual(False, result,
+                         f"Binary-Operation-Lexeme equality not matching: {False} != {result}")
+
+    @test("LEXEME BINARY-OPERATION EQ-FALSE-OPERAND")
+    def testBinaryOperationEqFalseOperand(self):
+        print(f"\t Validate: Constant(1) + Constant(2) == Constant(1) + Constant(3) -> {False}")
+
+        result = BinaryOperation(BinaryOperations.ADD, [Constant(1), Constant(2)]) == \
+                 BinaryOperation(BinaryOperations.ADD, [Constant(1), Constant(3)])
+
+        self.assertEqual(False, result,
+                         f"Binary-Operation-Lexeme equality not matching: {False} != {result}")

--- a/tests/test_smart_lambda_parse_binary_operation.py
+++ b/tests/test_smart_lambda_parse_binary_operation.py
@@ -2,7 +2,7 @@ import unittest
 from util import test
 
 from smart_lambda.core import SmartLambda
-from smart_lambda.lexeme import BinaryOperation, BinaryOperations, Parameter
+from smart_lambda.lexeme import BinaryOperation, BinaryOperations, Constant, Parameter
 
 
 class TestSmartLambdaBinaryOperation(unittest.TestCase):
@@ -123,6 +123,31 @@ class TestSmartLambdaBinaryOperation(unittest.TestCase):
         print(f"\t Validate: (lambda x, y: x >> y) -> {expected}")
 
         s_lambda = SmartLambda(lambda x, y: x >> y)
+        operations = s_lambda.binary_operations
+
+        self.assertEqual(expected, operations, f"Smart-Lambda operations not matching: {expected} != {operations}")
+
+    # The following test-cases are only executed for one parameter
+    # These are designed to test different combinations of operands (parameter and constant)
+
+    @test("SMART-LAMBDA PARSE-BINARY-OPERATION MIX-PARAM-CONST")
+    def testParseMixParamConst(self):
+        expected = [BinaryOperation(BinaryOperations.ADD, [Parameter('x'), Constant(1)])]
+
+        print(f"\t Validate: (lambda x: x + 1) -> {expected}")
+
+        s_lambda = SmartLambda(lambda x: x + 1)
+        operations = s_lambda.binary_operations
+
+        self.assertEqual(expected, operations, f"Smart-Lambda operations not matching: {expected} != {operations}")
+
+    @test("SMART-LAMBDA PARSE-BINARY-OPERATION MIX-CONST-PARAM")
+    def testParseMixConstParam(self):
+        expected = [BinaryOperation(BinaryOperations.ADD, [Constant(1), Parameter('x')])]
+
+        print(f"\t Validate: (lambda x: 1 + x) -> {expected}")
+
+        s_lambda = SmartLambda(lambda x: 1 + x)
         operations = s_lambda.binary_operations
 
         self.assertEqual(expected, operations, f"Smart-Lambda operations not matching: {expected} != {operations}")


### PR DESCRIPTION
Added test-cases for binary-operations with mixed parameter and constant operands.

Improved `__repr__` and `__eq__` methods on lexemes and tested using unit-tests.

Resolves #29 