### PR TITLE
Added test-cases for "nested" or complex binary-operations.

### DIFF
--- a/smart_lambda/lexeme.py
+++ b/smart_lambda/lexeme.py
@@ -99,7 +99,7 @@ class BinaryOperation(Lexeme):
         self.operands: List[Lexeme] = operands
 
     def __repr__(self):
-        return f"{self.operands[0]} {self.operation.value} {self.operands[1]}"
+        return f"Operation({self.operands[0]} {self.operation.value} {self.operands[1]})"
 
     def __eq__(self, other: BinaryOperation) -> bool:
         """

--- a/tests/test_lexeme.py
+++ b/tests/test_lexeme.py
@@ -105,7 +105,7 @@ class TestLexeme(unittest.TestCase):
 
     @test("LEXEME BINARY-OPERATION REPR-CONST-PARAM")
     def testBinaryOperationReprConstParam(self):
-        expected = f"Constant(1) + Parameter(x)"
+        expected = f"Operation(Constant(1) + Parameter(x))"
 
         print(f"\t Validate: BinaryOperation(BinaryOperations.ADD, [Constant(1), Parameter('x')]) -> {expected}")
 
@@ -116,7 +116,7 @@ class TestLexeme(unittest.TestCase):
 
     @test("LEXEME BINARY-OPERATION REPR-PARAM-CONST")
     def testBinaryOperationReprParamConst(self):
-        expected = f"Parameter(x) + Constant(1)"
+        expected = f"Operation(Parameter(x) + Constant(1))"
 
         print(f"\t Validate: BinaryOperation(BinaryOperations.ADD, [Parameter('x'), Constant(1)]) -> {expected}")
 

--- a/tests/test_smart_lambda_parse_binary_operation.py
+++ b/tests/test_smart_lambda_parse_binary_operation.py
@@ -127,9 +127,6 @@ class TestSmartLambdaBinaryOperation(unittest.TestCase):
 
         self.assertEqual(expected, operations, f"Smart-Lambda operations not matching: {expected} != {operations}")
 
-    # The following test-cases are only executed for one parameter
-    # These are designed to test different combinations of operands (parameter and constant)
-
     @test("SMART-LAMBDA PARSE-BINARY-OPERATION MIX-PARAM-CONST")
     def testParseMixParamConst(self):
         expected = [BinaryOperation(BinaryOperations.ADD, [Parameter('x'), Constant(1)])]
@@ -148,6 +145,73 @@ class TestSmartLambdaBinaryOperation(unittest.TestCase):
         print(f"\t Validate: (lambda x: 1 + x) -> {expected}")
 
         s_lambda = SmartLambda(lambda x: 1 + x)
+        operations = s_lambda.binary_operations
+
+        self.assertEqual(expected, operations, f"Smart-Lambda operations not matching: {expected} != {operations}")
+
+    @test("SMART-LAMBDA PARSE-BINARY-OPERATION COMPLEX-1")
+    def testParseComplex1(self):
+        operation_inner = BinaryOperation(BinaryOperations.ADD, [Parameter('x'), Parameter('y')])
+        operation_outer = BinaryOperation(BinaryOperations.ADD, [operation_inner, Parameter('z')])
+        expected = [operation_inner, operation_outer]
+
+        print(f"\t Validate: (lambda x, y, z: x + y + z) -> {expected}")
+
+        s_lambda = SmartLambda(lambda x, y, z: x + y + z)
+        operations = s_lambda.binary_operations
+
+        self.assertEqual(expected, operations, f"Smart-Lambda operations not matching: {expected} != {operations}")
+
+    @test("SMART-LAMBDA PARSE-BINARY-OPERATION COMPLEX-2")
+    def testParseComplex2(self):
+        operation_inner = BinaryOperation(BinaryOperations.MUL, [Parameter('x'), Parameter('y')])
+        operation_outer = BinaryOperation(BinaryOperations.ADD, [operation_inner, Parameter('z')])
+        expected = [operation_inner, operation_outer]
+
+        print(f"\t Validate: (lambda x, y, z: x * y + z) -> {expected}")
+
+        s_lambda = SmartLambda(lambda x, y, z: x * y + z)
+        operations = s_lambda.binary_operations
+
+        self.assertEqual(expected, operations, f"Smart-Lambda operations not matching: {expected} != {operations}")
+
+    @unittest.skip
+    @test("SMART-LAMBDA PARSE-BINARY-OPERATION COMPLEX-3")
+    def testParseComplex3(self):
+        operation_inner = BinaryOperation(BinaryOperations.MUL, [Parameter('y'), Parameter('z')])
+        operation_outer = BinaryOperation(BinaryOperations.ADD, [Parameter('x'), operation_inner])
+        expected = [operation_inner, operation_outer]
+
+        print(f"\t Validate: (lambda x, y, z: x + y * z) -> {expected}")
+
+        s_lambda = SmartLambda(lambda x, y, z: x + y * z)
+        operations = s_lambda.binary_operations
+
+        self.assertEqual(expected, operations, f"Smart-Lambda operations not matching: {expected} != {operations}")
+
+    @test("SMART-LAMBDA PARSE-BINARY-OPERATION COMPLEX-4")
+    def testParseComplex4(self):
+        operation_inner = BinaryOperation(BinaryOperations.ADD, [Parameter('x'), Parameter('y')])
+        operation_outer = BinaryOperation(BinaryOperations.MUL, [operation_inner, Parameter('z')])
+        expected = [operation_inner, operation_outer]
+
+        print(f"\t Validate: (lambda x, y, z: (x + y) * z) -> {expected}")
+
+        s_lambda = SmartLambda(lambda x, y, z: (x + y) * z)
+        operations = s_lambda.binary_operations
+
+        self.assertEqual(expected, operations, f"Smart-Lambda operations not matching: {expected} != {operations}")
+
+    @unittest.skip
+    @test("SMART-LAMBDA PARSE-BINARY-OPERATION COMPLEX-5")
+    def testParseComplex5(self):
+        operation_inner = BinaryOperation(BinaryOperations.ADD, [Parameter('y'), Parameter('z')])
+        operation_outer = BinaryOperation(BinaryOperations.MUL, [Parameter('x'), operation_inner])
+        expected = [operation_inner, operation_outer]
+
+        print(f"\t Validate: (lambda x, y, z: x * (y + z)) -> {expected}")
+
+        s_lambda = SmartLambda(lambda x, y, z: x * (y + z))
         operations = s_lambda.binary_operations
 
         self.assertEqual(expected, operations, f"Smart-Lambda operations not matching: {expected} != {operations}")


### PR DESCRIPTION
Added test-cases for complex binary-operation.

Found combinations of "+" and "*" which are parsed incorrectly.
This should be addressed in a separate ticket.

Resolves #30