### PR TITLE
35 fix parserbinaryoperation for more complex combinations

### DIFF
--- a/smart_lambda/parser/parser_binary_operation.py
+++ b/smart_lambda/parser/parser_binary_operation.py
@@ -39,4 +39,32 @@ class ParserBinaryOperation(ParserLexeme):
         """
         super().parse(lexemes, instruction)
 
-        return BinaryOperation(cls.instructions[instruction.opname], lexemes[-2:])
+        return BinaryOperation(cls.instructions[instruction.opname], cls.get_operands(lexemes))
+
+    @classmethod
+    def get_operands(cls, lexemes: List[Lexeme]) -> List[Lexeme]:
+        """
+        Get the two operands for the binary-operation based on the already parsed lexemes
+
+        :param lexemes: List of already parsed lexemes
+
+        :return: List of operands
+        """
+        operands = []
+
+        # Iterate lexemes in reversed order
+        lexemes_iter = iter(lexemes[::-1])
+        for lexeme in lexemes_iter:
+            operands.append(lexeme)
+
+            # If lexeme was binary operation, skip next two lexemes (operands of operation)
+            if isinstance(lexeme, BinaryOperation):
+                next(lexemes_iter)
+                next(lexemes_iter)
+
+            # Break when 2 operands where found
+            if len(operands) == 2:
+                break
+
+        # Fix order of operands and return
+        return operands[::-1]

--- a/tests/test_smart_lambda_parse_binary_operation.py
+++ b/tests/test_smart_lambda_parse_binary_operation.py
@@ -175,7 +175,6 @@ class TestSmartLambdaBinaryOperation(unittest.TestCase):
 
         self.assertEqual(expected, operations, f"Smart-Lambda operations not matching: {expected} != {operations}")
 
-    @unittest.skip
     @test("SMART-LAMBDA PARSE-BINARY-OPERATION COMPLEX-3")
     def testParseComplex3(self):
         operation_inner = BinaryOperation(BinaryOperations.MUL, [Parameter('y'), Parameter('z')])
@@ -202,7 +201,6 @@ class TestSmartLambdaBinaryOperation(unittest.TestCase):
 
         self.assertEqual(expected, operations, f"Smart-Lambda operations not matching: {expected} != {operations}")
 
-    @unittest.skip
     @test("SMART-LAMBDA PARSE-BINARY-OPERATION COMPLEX-5")
     def testParseComplex5(self):
         operation_inner = BinaryOperation(BinaryOperations.ADD, [Parameter('y'), Parameter('z')])

--- a/tests/test_smart_lambda_parse_binary_operation.py
+++ b/tests/test_smart_lambda_parse_binary_operation.py
@@ -213,3 +213,18 @@ class TestSmartLambdaBinaryOperation(unittest.TestCase):
         operations = s_lambda.binary_operations
 
         self.assertEqual(expected, operations, f"Smart-Lambda operations not matching: {expected} != {operations}")
+
+    @test("SMART-LAMBDA PARSE-BINARY-OPERATION COMPLEX-6")
+    def testParseComplex6(self):
+        operation_l = BinaryOperation(BinaryOperations.MUL, [Parameter('x'), Parameter('y')])
+        operation_r = BinaryOperation(BinaryOperations.MUL, [Parameter('x'), Parameter('z')])
+        operation_add = BinaryOperation(BinaryOperations.ADD, [operation_l, operation_r])
+
+        expected = [operation_l, operation_r, operation_add]
+
+        print(f"\t Validate: (lambda x, y, z: x * y + x * z) -> {expected}")
+
+        s_lambda = SmartLambda(lambda x, y, z: x * y + x * z)
+        operations = s_lambda.binary_operations
+
+        self.assertEqual(expected, operations, f"Smart-Lambda operations not matching: {expected} != {operations}")


### PR DESCRIPTION
Fixed `ParserBinaryOperation` by implementing `get_operands`.

This method ensures the correct operands are loaded based on the already parsed lexemes.

Resolves #35