### PR TITLE
41 add test case for binary operation including an unary operation

### DIFF
--- a/smart_lambda/parser/parser_binary_operation.py
+++ b/smart_lambda/parser/parser_binary_operation.py
@@ -2,7 +2,7 @@ from typing import List, Union
 
 from dis import Instruction
 
-from smart_lambda.lexeme import Lexeme, BinaryOperation, BinaryOperations
+from smart_lambda.lexeme import Lexeme, BinaryOperation, BinaryOperations, UnaryOperation
 from smart_lambda.parser.parser_lexeme import ParserLexeme
 
 
@@ -60,6 +60,10 @@ class ParserBinaryOperation(ParserLexeme):
             # If lexeme was binary operation, skip next two lexemes (operands of operation)
             if isinstance(lexeme, BinaryOperation):
                 next(lexemes_iter)
+                next(lexemes_iter)
+
+            # If lexeme was unary operation, skip next lexeme (operand of operation)
+            if isinstance(lexeme, UnaryOperation):
                 next(lexemes_iter)
 
             # Break when 2 operands where found

--- a/smart_lambda/parser/parser_binary_operation.py
+++ b/smart_lambda/parser/parser_binary_operation.py
@@ -50,25 +50,15 @@ class ParserBinaryOperation(ParserLexeme):
 
         :return: List of operands
         """
-        operands = []
+        operands = [lexemes[-1]]
 
-        # Iterate lexemes in reversed order
-        lexemes_iter = iter(lexemes[::-1])
-        for lexeme in lexemes_iter:
-            operands.append(lexeme)
+        if isinstance(operands[0], UnaryOperation):
+            operands.append(lexemes[-3])
 
-            # If lexeme was binary operation, skip next two lexemes (operands of operation)
-            if isinstance(lexeme, BinaryOperation):
-                next(lexemes_iter)
-                next(lexemes_iter)
+        elif isinstance(operands[0], BinaryOperation):
+            operands.append(lexemes[-4])
 
-            # If lexeme was unary operation, skip next lexeme (operand of operation)
-            if isinstance(lexeme, UnaryOperation):
-                next(lexemes_iter)
+        else:
+            operands.append(lexemes[-2])
 
-            # Break when 2 operands where found
-            if len(operands) == 2:
-                break
-
-        # Fix order of operands and return
         return operands[::-1]

--- a/tests/test_smart_lambda_parse_binary_operation.py
+++ b/tests/test_smart_lambda_parse_binary_operation.py
@@ -2,7 +2,7 @@ import unittest
 from util import test
 
 from smart_lambda.core import SmartLambda
-from smart_lambda.lexeme import BinaryOperation, BinaryOperations, Constant, Parameter
+from smart_lambda.lexeme import BinaryOperation, BinaryOperations, Constant, Parameter, UnaryOperation, UnaryOperations
 
 
 class TestSmartLambdaBinaryOperation(unittest.TestCase):
@@ -225,6 +225,20 @@ class TestSmartLambdaBinaryOperation(unittest.TestCase):
         print(f"\t Validate: (lambda x, y, z: x * y + x * z) -> {expected}")
 
         s_lambda = SmartLambda(lambda x, y, z: x * y + x * z)
+        operations = s_lambda.binary_operations
+
+        self.assertEqual(expected, operations, f"Smart-Lambda operations not matching: {expected} != {operations}")
+
+    @test("SMART-LAMBDA PARSE-BINARY-OPERATION UNARY-OPERATION")
+    def testParseUnaryOperation(self):
+        operation_inv = UnaryOperation(UnaryOperations.INV, Parameter('y'))
+        operation_add = BinaryOperation(BinaryOperations.ADD, [Parameter('x'), operation_inv])
+
+        expected = [operation_add]
+
+        print(f"\t Validate: (lambda x, y: x + ~y) -> {expected}")
+
+        s_lambda = SmartLambda(lambda x, y: x + ~y)
         operations = s_lambda.binary_operations
 
         self.assertEqual(expected, operations, f"Smart-Lambda operations not matching: {expected} != {operations}")


### PR DESCRIPTION
Fixed `ParserBinaryOperation` for statements including unary-operations.

Additionally refactored the `get_operands` method.

Resolves #41